### PR TITLE
エラーレスポンスにエラーコードを追加

### DIFF
--- a/app/controllers/concerns/render_error_util.rb
+++ b/app/controllers/concerns/render_error_util.rb
@@ -16,6 +16,7 @@ module RenderErrorUtil
       errors: {
         status: '400',
         title: 'Bad Request',
+        code: '10001',
         detail: message
       }.compact
     }, status: :bad_request
@@ -26,6 +27,7 @@ module RenderErrorUtil
       errors: {
         status: '401',
         title: 'Unauthorized',
+        code: '10002',
         detail: 'Invalid credentials'
       }
     }, status: :unauthorized
@@ -35,6 +37,7 @@ module RenderErrorUtil
     render content_type: 'application/json', json: {
       errors: {
         status: '403',
+        code: '10003',
         title: 'Forbidden'
       }
     }, status: :forbidden
@@ -44,6 +47,7 @@ module RenderErrorUtil
     render content_type: 'application/json', json: {
       errors: {
         status: '404',
+        code: '10004',
         title: 'User Not Found'
       }
     }, status: :not_found
@@ -53,6 +57,7 @@ module RenderErrorUtil
     render content_type: 'application/json', json: {
       errors: {
         status: '404',
+        code: '10005',
         title: 'Not Found'
       }
     }, status: :not_found
@@ -62,6 +67,7 @@ module RenderErrorUtil
     render content_type: 'application/json', json: {
       errors: {
         status: '405',
+        code: '10006',
         title: 'Method Not Allowed'
       }
     }, status: :method_not_allowed
@@ -71,6 +77,7 @@ module RenderErrorUtil
     render content_type: 'application/json', json: {
       errors: {
         status: '500',
+        code: '20001',
         title: 'Internal Server Error'
       }
     }, status: :internal_server_error


### PR DESCRIPTION
## タスク
エラーコードの追加
https://www.notion.so/5d2345cd0a2e4d4f9e762ed738e55ebc?pvs=4

## 対応
`render_error_util.rb`で定義されているエラーレスポンスにエラーコードを追加

## before / after
`/v1/users/:display_id`
存在しない`display_id`にリクエストした時
### before
```
{
  "errors": {
    "status": "404",
    "title": "Not Found"
  }
}
```
### after
```
{
  "errors": {
    "status": "404",
    "code": "10005",
    "title": "Not Found"
  }
}
```
## 注意点
開発環境でレスポンスを確認するには`config/environments/development.rb`の`config.consider_all_requests_local = ture`を`false`にすることで確認できる。

https://railsdoc.com/page/config_consider_all_requests_local
